### PR TITLE
Convert portfolio to SPA-style single-page experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -56,6 +56,10 @@
   body {
     @apply bg-background text-foreground;
   }
+  html {
+    scroll-behavior: smooth;
+  }
+
 }
 
 @layer utilities {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,38 @@
 import { HeroSection } from "@/components/hero-section"
 import { LatestProducts } from "@/components/latest-products"
+import { BlogCard } from "@/components/blog-card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { getZennArticles, getZennProductArticles } from "@/lib/zenn"
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  Code,
+  Coffee,
+  Github,
+  Instagram,
+  Lightbulb,
+  Mail,
+  MessageCircle,
+  Package,
+  Rocket,
+} from "lucide-react"
 import { Suspense, lazy } from "react"
+import { RiTwitterXFill } from "react-icons/ri"
 
-// 他のコンポーネントを遅延読み込み
-const CodeAnimation = lazy(() => import("@/components/code-animation").then(m => ({ default: m.CodeAnimation })))
+const CodeAnimation = lazy(() => import("@/components/code-animation").then((m) => ({ default: m.CodeAnimation })))
 
-// フォールバック用のローディングコンポーネント
 function SectionSkeleton() {
   return (
     <div className="container mx-auto px-4 py-16">
       <div className="animate-pulse">
-        <div className="h-8 bg-gray-300 rounded mb-4 w-1/3 mx-auto"></div>
-        <div className="h-4 bg-gray-300 rounded mb-8 w-1/2 mx-auto"></div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div className="mx-auto mb-4 h-8 w-1/3 rounded bg-gray-300"></div>
+        <div className="mx-auto mb-8 h-4 w-1/2 rounded bg-gray-300"></div>
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           {[...Array(3)].map((_, i) => (
-            <div key={i} className="h-64 bg-gray-300 rounded-lg"></div>
+            <div key={i} className="h-64 rounded-lg bg-gray-300"></div>
           ))}
         </div>
       </div>
@@ -22,20 +40,323 @@ function SectionSkeleton() {
   )
 }
 
-export default function HomePage() {
+export default async function HomePage() {
+  const [articles, products] = await Promise.all([getZennArticles("dokkiitech"), getZennProductArticles("dokkiitech")])
+
+  const skills = ["Next.js", "React", "TypeScript", "CloudFlare", "AWS", "Docker", "PostgreSQL", "Python", "Java", "GAS"]
+
+  const experiences = [
+    {
+      title: "福岡デザイン&テクノロジー専門学校 ホワイトハッカー専攻",
+      period: "202404 - 現在",
+      description: "現在2年生ホワイトハッカーを育成するための専攻でセキュリティについての知識を勉強しています",
+    },
+    {
+      title: "インターン先 S様",
+      period: "20202507 - ",
+      description: "中長期インターンにてサーバーサイド業務を中心に活動",
+    },
+    {
+      title: "インターン先 W様",
+      period: "20202507 - ",
+      description: "中長期インターンに参加中",
+    },
+  ]
+
+  const socialLinks = [
+    {
+      name: "GitHub",
+      icon: Github,
+      url: "https://github.com/dokkiitech",
+      color: "hover:text-gray-900 dark:hover:text-gray-100",
+    },
+    {
+      name: "X",
+      icon: RiTwitterXFill,
+      url: "https://x.com/dokkiitech",
+      color: "hover:text-blue-500",
+    },
+    {
+      name: "Instagram",
+      icon: Instagram,
+      url: "https://instagram.com/dokkiitech",
+      color: "hover:text-blue-600",
+    },
+    {
+      name: "Mail",
+      icon: Mail,
+      url: "mailto:info@dokkiitech.com",
+      color: "hover:text-indigo-500",
+    },
+  ]
+
   return (
     <main className="min-h-screen">
-      {/* ヒーローセクションを最優先で読み込み */}
-      <HeroSection />
+      <section id="home" className="scroll-mt-24">
+        <HeroSection />
+      </section>
 
-      {/* 他のコンポーネントは遅延読み込み */}
       <Suspense fallback={<SectionSkeleton />}>
         <CodeAnimation />
       </Suspense>
 
-      <Suspense fallback={<SectionSkeleton />}>
-        <LatestProducts />
-      </Suspense>
+      <section id="products" className="scroll-mt-24">
+        <Suspense fallback={<SectionSkeleton />}>
+          <LatestProducts />
+        </Suspense>
+      </section>
+
+      <section id="about" className="container mx-auto max-w-4xl scroll-mt-24 px-4 py-16">
+        <div className="mb-16 text-center">
+          <h2 className="mb-4 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-4xl font-bold text-transparent">About Me</h2>
+          <p className="text-xl text-muted-foreground">システムエンジニアとしての詳細なプロフィール</p>
+        </div>
+
+        <div className="grid gap-8 md:gap-12">
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-blue-500 to-purple-500">
+                  <Code className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">プロフィール</h3>
+              </div>
+              <div className="space-y-4 leading-relaxed text-muted-foreground">
+                <p>当サイトをご覧いただきありがとうございます。福岡デザイン＆テクノロジー専門学校 ホワイトハッカー専攻2年の木戸亮輔です。</p>
+                <p>学校ではセキュリティ分野の学習に力を入れており、普段の個人開発ではフロント開発をはじめバックインフラなどフルスタックで開発をしています。</p>
+                <p>モダンな技術を使うのが大好きでハッカソンなど出場時は新しい技術を必ず取り入れるようにしています。</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-green-500 to-blue-500">
+                  <Lightbulb className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">スキル</h3>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                {skills.map((skill) => (
+                  <Badge key={skill} variant="secondary" className="rounded-full px-4 py-2 text-sm font-medium transition-transform hover:scale-105">
+                    {skill}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-purple-500 to-pink-500">
+                  <Rocket className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">経験</h3>
+              </div>
+              <div className="space-y-6">
+                {experiences.map((exp, index) => (
+                  <div key={index} className="border-l-4 border-primary/20 pb-6 pl-6 last:pb-0">
+                    <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <h4 className="text-lg font-semibold">{exp.title}</h4>
+                      <Badge variant="outline" className="w-fit rounded-full">
+                        {exp.period}
+                      </Badge>
+                    </div>
+                    <p className="text-muted-foreground">{exp.description}</p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-orange-500 to-red-500">
+                  <Coffee className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">趣味</h3>
+              </div>
+              <div className="space-y-4 leading-relaxed text-muted-foreground">
+                <p>休日にDJプレイをしています。DJ以外にも身体を動かしたり、開発したりするのが大好きです。</p>
+                <p>実は剣道3段を持っています。</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section id="blog" className="container mx-auto scroll-mt-24 px-4 py-16">
+        <div className="mb-12 text-center">
+          <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+            <BookOpen className="h-8 w-8 text-primary" />
+          </div>
+          <h2 className="mb-4 text-4xl font-bold">ブログ</h2>
+          <p className="mx-auto max-w-2xl text-muted-foreground">Zennで技術記事を投稿しています。プログラミング、開発ツール、技術トレンドなどについて書いています。</p>
+        </div>
+
+        {articles.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {articles.map((article) => (
+              <BlogCard key={article.link} article={article} />
+            ))}
+          </div>
+        ) : (
+          <div className="py-12 text-center">
+            <p className="text-muted-foreground">記事を読み込めませんでした。</p>
+          </div>
+        )}
+      </section>
+
+      <section id="all-products" className="container mx-auto scroll-mt-24 px-4 py-16">
+        <div className="mb-12 text-center">
+          <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+            <Package className="h-8 w-8 text-primary" />
+          </div>
+          <h2 className="mb-4 text-4xl font-bold">Products</h2>
+          <p className="mx-auto max-w-2xl text-muted-foreground">これまで開発したプロダクトの一覧です。各プロダクトの詳細はZennで公開しています。</p>
+        </div>
+
+        {products.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {products.map((article) => (
+              <BlogCard key={article.link} article={article} />
+            ))}
+          </div>
+        ) : (
+          <div className="py-12 text-center">
+            <p className="text-muted-foreground">プロダクトを準備中です。</p>
+          </div>
+        )}
+      </section>
+
+      <section id="contact" className="container mx-auto max-w-4xl scroll-mt-24 px-4 py-16">
+        <div className="mb-16 text-center">
+          <h2 className="mb-4 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-4xl font-bold text-transparent">Contact</h2>
+          <p className="text-xl text-muted-foreground">お気軽にお声がけください</p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-blue-500 to-purple-500">
+                  <Mail className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">SNS</h3>
+              </div>
+              <div className="space-y-4">
+                {socialLinks.map((link) => (
+                  <Button key={link.name} variant="ghost" size="lg" className={`h-14 w-full justify-start rounded-2xl transition-colors ${link.color}`} asChild>
+                    <a href={link.url} target="_blank" rel="noopener noreferrer">
+                      <link.icon className="mr-4 h-6 w-6" />
+                      <span className="text-lg">{link.name}</span>
+                      <span className="ml-auto text-sm text-muted-foreground">@dokkiitech</span>
+                    </a>
+                  </Button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-green-500 to-blue-500">
+                  <MessageCircle className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">メッセージ</h3>
+              </div>
+              <div className="space-y-6">
+                <p className="leading-relaxed text-muted-foreground">プロジェクトのご相談、技術的な質問、コラボレーションのお誘いなど、どんなことでもお気軽にご連絡ください。</p>
+                <p className="leading-relaxed text-muted-foreground">お急ぎの場合は、各種SNSよりダイレクトメッセージをお送りいただけると 迅速にお返事いたします。</p>
+                <div className="rounded-2xl bg-muted/50 p-4">
+                  <p className="text-sm text-muted-foreground">通常、24時間以内にお返事いたします。 お仕事のご依頼の場合は、詳細をお聞かせください。</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section id="appoint" className="container mx-auto max-w-4xl scroll-mt-24 px-4 py-16">
+        <div className="mb-16 text-center">
+          <h2 className="mb-4 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-4xl font-bold text-transparent">Appointment</h2>
+          <p className="text-xl text-muted-foreground">お打ち合わせのご予約</p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-blue-500 to-purple-500">
+                  <Calendar className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">予約システム</h3>
+              </div>
+              <div className="space-y-6">
+                <p className="leading-relaxed text-muted-foreground">お打ち合わせのご予約はこちらからお願いします。お急ぎの場合は各種SNSよりご連絡ください。</p>
+                <Button size="lg" className="h-14 w-full rounded-2xl bg-gradient-to-r from-blue-500 to-purple-500 text-lg hover:from-blue-600 hover:to-purple-600" asChild>
+                  <a
+                    href="https://calendar.google.com/calendar/u/0/appointments/AcZssZ3whB7e22y-Jp_M3XR9B8drZ8rJji3IGLGfAsw="
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Calendar className="mr-3 h-6 w-6" />
+                    予約する
+                  </a>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-3xl border-2 transition-all duration-300 hover:shadow-lg">
+            <CardContent className="p-8">
+              <div className="mb-6 flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-r from-green-500 to-blue-500">
+                  <Clock className="h-6 w-6 text-white" />
+                </div>
+                <h3 className="text-2xl font-bold">詳細</h3>
+              </div>
+              <div className="space-y-6">
+                <div className="space-y-4">
+                  <div className="flex items-start gap-3">
+                    <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-primary"></div>
+                    <div>
+                      <h4 className="mb-1 font-semibold">対応時間</h4>
+                      <p className="text-sm text-muted-foreground">平日 11:00 - 23:59</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-primary"></div>
+                    <div>
+                      <h4 className="mb-1 font-semibold">所要時間</h4>
+                      <p className="text-sm text-muted-foreground">30分 - 60分程度</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-primary"></div>
+                    <div>
+                      <h4 className="mb-1 font-semibold">形式</h4>
+                      <p className="text-sm text-muted-foreground">オンライン（Google Meet）</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-2xl bg-muted/50 p-4">
+                  <div className="mb-2 flex items-center gap-2">
+                    <MessageCircle className="h-4 w-4 text-primary" />
+                    <span className="text-sm font-medium">お急ぎの場合</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">各種SNSよりダイレクトメッセージでご連絡ください。 迅速に対応いたします。</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
     </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,9 @@ import { BlogCard } from "@/components/blog-card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { getZennArticles, getZennProductArticles } from "@/lib/zenn"
+import { getZennArticles } from "@/lib/zenn"
 import {
+  ArrowRight,
   BookOpen,
   Calendar,
   Clock,
@@ -16,9 +17,9 @@ import {
   Lightbulb,
   Mail,
   MessageCircle,
-  Package,
   Rocket,
 } from "lucide-react"
+import Link from "next/link"
 import { Suspense, lazy } from "react"
 import { RiTwitterXFill } from "react-icons/ri"
 
@@ -41,7 +42,7 @@ function SectionSkeleton() {
 }
 
 export default async function HomePage() {
-  const [articles, products] = await Promise.all([getZennArticles("dokkiitech"), getZennProductArticles("dokkiitech")])
+  const latestArticles = (await getZennArticles("dokkiitech")).slice(0, 3)
 
   const skills = ["Next.js", "React", "TypeScript", "CloudFlare", "AWS", "Docker", "PostgreSQL", "Python", "Java", "GAS"]
 
@@ -104,6 +105,41 @@ export default async function HomePage() {
         <Suspense fallback={<SectionSkeleton />}>
           <LatestProducts />
         </Suspense>
+      </section>
+
+      <section id="blog" className="container mx-auto scroll-mt-24 px-4 py-16">
+        <div className="mb-12 text-center">
+          <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+            <BookOpen className="h-8 w-8 text-primary" />
+          </div>
+          <h2 className="mb-4 text-4xl font-bold">ブログ</h2>
+          <p className="mx-auto max-w-2xl text-muted-foreground">最新の記事を3件表示しています。すべての記事はブログページで確認できます。</p>
+        </div>
+
+        {latestArticles.length > 0 ? (
+          <>
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {latestArticles.map((article) => (
+                <BlogCard key={article.link} article={article} />
+              ))}
+            </div>
+            <div className="mt-10 text-center">
+              <Button size="lg" variant="outline" className="rounded-full border-2 px-8 py-6 text-lg transition-all duration-300 hover:bg-muted/50" asChild>
+                <Link href="/blog">
+                  すべての記事を見る
+                  <ArrowRight className="ml-2 h-5 w-5" />
+                </Link>
+              </Button>
+            </div>
+          </>
+        ) : (
+          <div className="py-12 text-center">
+            <p className="text-muted-foreground">記事を読み込めませんでした。</p>
+            <Link href="/blog" className="mt-4 inline-block text-primary hover:underline">
+              ブログページを見る →
+            </Link>
+          </div>
+        )}
       </section>
 
       <section id="about" className="container mx-auto max-w-4xl scroll-mt-24 px-4 py-16">
@@ -186,50 +222,6 @@ export default async function HomePage() {
             </CardContent>
           </Card>
         </div>
-      </section>
-
-      <section id="blog" className="container mx-auto scroll-mt-24 px-4 py-16">
-        <div className="mb-12 text-center">
-          <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-            <BookOpen className="h-8 w-8 text-primary" />
-          </div>
-          <h2 className="mb-4 text-4xl font-bold">ブログ</h2>
-          <p className="mx-auto max-w-2xl text-muted-foreground">Zennで技術記事を投稿しています。プログラミング、開発ツール、技術トレンドなどについて書いています。</p>
-        </div>
-
-        {articles.length > 0 ? (
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {articles.map((article) => (
-              <BlogCard key={article.link} article={article} />
-            ))}
-          </div>
-        ) : (
-          <div className="py-12 text-center">
-            <p className="text-muted-foreground">記事を読み込めませんでした。</p>
-          </div>
-        )}
-      </section>
-
-      <section id="all-products" className="container mx-auto scroll-mt-24 px-4 py-16">
-        <div className="mb-12 text-center">
-          <div className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-            <Package className="h-8 w-8 text-primary" />
-          </div>
-          <h2 className="mb-4 text-4xl font-bold">Products</h2>
-          <p className="mx-auto max-w-2xl text-muted-foreground">これまで開発したプロダクトの一覧です。各プロダクトの詳細はZennで公開しています。</p>
-        </div>
-
-        {products.length > 0 ? (
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {products.map((article) => (
-              <BlogCard key={article.link} article={article} />
-            ))}
-          </div>
-        ) : (
-          <div className="py-12 text-center">
-            <p className="text-muted-foreground">プロダクトを準備中です。</p>
-          </div>
-        )}
       </section>
 
       <section id="contact" className="container mx-auto max-w-4xl scroll-mt-24 px-4 py-16">

--- a/components/latest-products.tsx
+++ b/components/latest-products.tsx
@@ -34,7 +34,7 @@ export async function LatestProducts() {
             className="rounded-full px-8 py-6 text-lg border-2 hover:bg-muted/50 transition-all duration-300"
             asChild
           >
-            <Link href="/products">
+            <Link href="/#all-products">
               すべてのプロダクトを見る
               <ArrowRight className="ml-2 w-5 h-5" />
             </Link>

--- a/components/latest-products.tsx
+++ b/components/latest-products.tsx
@@ -34,7 +34,7 @@ export async function LatestProducts() {
             className="rounded-full px-8 py-6 text-lg border-2 hover:bg-muted/50 transition-all duration-300"
             asChild
           >
-            <Link href="/#all-products">
+            <Link href="/products">
               すべてのプロダクトを見る
               <ArrowRight className="ml-2 w-5 h-5" />
             </Link>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
@@ -8,37 +8,45 @@ import { ThemeToggle } from "@/components/theme-toggle"
 import { Menu, X } from "lucide-react"
 
 const navigation = [
-  { name: "Home", href: "/" },
-  { name: "About", href: "/about" },
-  { name: "Products", href: "/products" },
-  { name: "Blog", href: "/blog" },
-  { name: "Contact", href: "/contact" },
-  { name: "Appoint", href: "/appoint" },
+  { name: "Home", href: "/#home", hash: "#home" },
+  { name: "About", href: "/#about", hash: "#about" },
+  { name: "Products", href: "/#all-products", hash: "#all-products" },
+  { name: "Blog", href: "/#blog", hash: "#blog" },
+  { name: "Contact", href: "/#contact", hash: "#contact" },
+  { name: "Appoint", href: "/#appoint", hash: "#appoint" },
 ]
 
 export function Navigation() {
   const [isOpen, setIsOpen] = useState(false)
+  const [currentHash, setCurrentHash] = useState("#home")
   const pathname = usePathname()
+
+  useEffect(() => {
+    const updateHash = () => {
+      setCurrentHash(window.location.hash || "#home")
+    }
+
+    updateHash()
+    window.addEventListener("hashchange", updateHash)
+
+    return () => window.removeEventListener("hashchange", updateHash)
+  }, [])
 
   return (
     <>
-      <nav className="fixed top-0 w-full z-50 bg-background/80 backdrop-blur-md border-b">
+      <nav className="fixed top-0 z-50 w-full border-b bg-background/80 backdrop-blur-md">
         <div className="container mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
-            {/* ロゴ */}
-            <Link href="/" className="flex items-center space-x-2">
-              <span className="text-2xl font-bold bg-gradient-to-r from-blue-500 to-purple-500 bg-clip-text text-transparent">
-                {"<>"}
-              </span>
-              <span className="font-bold text-lg">dokkiitech.com</span>
+          <div className="flex h-16 items-center justify-between">
+            <Link href="/#home" className="flex items-center space-x-2">
+              <span className="bg-gradient-to-r from-blue-500 to-purple-500 bg-clip-text text-2xl font-bold text-transparent">{"<>"}</span>
+              <span className="text-lg font-bold">dokkiitech.com</span>
             </Link>
 
-            {/* デスクトップナビゲーション */}
-            <div className="hidden md:flex items-center space-x-1">
+            <div className="hidden items-center space-x-1 md:flex">
               {navigation.map((item) => (
                 <Button
                   key={item.name}
-                  variant={pathname === item.href ? "default" : "ghost"}
+                  variant={pathname === "/" && currentHash === item.hash ? "default" : "ghost"}
                   className="rounded-full"
                   asChild
                 >
@@ -47,28 +55,18 @@ export function Navigation() {
               ))}
             </div>
 
-            {/* 右側のボタン */}
             <div className="flex items-center space-x-2">
               <ThemeToggle />
 
-              {/* モバイルメニューボタン */}
               <Button
                 variant="ghost"
                 size="icon"
-                className="md:hidden rounded-full bg-gradient-to-r from-blue-500/10 to-purple-500/10 hover:from-blue-500/20 hover:to-purple-500/20 transition-all duration-300 hover:scale-105"
+                className="rounded-full bg-gradient-to-r from-blue-500/10 to-purple-500/10 transition-all duration-300 hover:scale-105 hover:from-blue-500/20 hover:to-purple-500/20 md:hidden"
                 onClick={() => setIsOpen(!isOpen)}
               >
-                <div className="relative w-5 h-5">
-                  <Menu
-                    className={`w-5 h-5 absolute transition-all duration-300 ${
-                      isOpen ? "rotate-90 opacity-0" : "rotate-0 opacity-100"
-                    }`}
-                  />
-                  <X
-                    className={`w-5 h-5 absolute transition-all duration-300 ${
-                      isOpen ? "rotate-0 opacity-100" : "-rotate-90 opacity-0"
-                    }`}
-                  />
+                <div className="relative h-5 w-5">
+                  <Menu className={`absolute h-5 w-5 transition-all duration-300 ${isOpen ? "rotate-90 opacity-0" : "rotate-0 opacity-100"}`} />
+                  <X className={`absolute h-5 w-5 transition-all duration-300 ${isOpen ? "rotate-0 opacity-100" : "-rotate-90 opacity-0"}`} />
                 </div>
               </Button>
             </div>
@@ -76,34 +74,27 @@ export function Navigation() {
         </div>
       </nav>
 
-      {/* フルスクリーンモバイルメニュー */}
       <div
-        className={`fixed inset-0 z-40 md:hidden transition-all duration-300 ease-in-out ${
-          isOpen ? "opacity-100 visible" : "opacity-0 invisible"
+        className={`fixed inset-0 z-40 transition-all duration-300 ease-in-out md:hidden ${
+          isOpen ? "visible opacity-100" : "invisible opacity-0"
         }`}
       >
-        {/* 背景オーバーレイ */}
         <div className="absolute inset-0 bg-background/95 backdrop-blur-lg" onClick={() => setIsOpen(false)} />
 
-        {/* メニューコンテンツ */}
-        <div className="relative flex flex-col items-center justify-center h-full px-8">
-
-          {/* ナビゲーションリンク */}
+        <div className="relative flex h-full flex-col items-center justify-center px-8">
           <div className="flex flex-col items-center space-y-6">
             {navigation.map((item, index) => (
               <div
                 key={item.name}
-                className={`transition-all duration-500 ${
-                  isOpen ? "translate-y-0 opacity-100" : "translate-y-8 opacity-0"
-                }`}
+                className={`transition-all duration-500 ${isOpen ? "translate-y-0 opacity-100" : "translate-y-8 opacity-0"}`}
                 style={{
                   transitionDelay: `${index * 100}ms`,
                 }}
               >
                 <Button
-                  variant={pathname === item.href ? "default" : "ghost"}
+                  variant={pathname === "/" && currentHash === item.hash ? "default" : "ghost"}
                   size="lg"
-                  className="text-2xl py-6 px-8 rounded-full min-w-[200px] bg-gradient-to-r from-blue-500/5 to-purple-500/5 hover:from-blue-500/20 hover:to-purple-500/20 transition-all duration-300 hover:scale-105"
+                  className="min-w-[200px] rounded-full bg-gradient-to-r from-blue-500/5 to-purple-500/5 px-8 py-6 text-2xl transition-all duration-300 hover:scale-105 hover:from-blue-500/20 hover:to-purple-500/20"
                   asChild
                   onClick={() => setIsOpen(false)}
                 >
@@ -112,7 +103,6 @@ export function Navigation() {
               </div>
             ))}
           </div>
-
         </div>
       </div>
     </>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -7,11 +7,17 @@ import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { Menu, X } from "lucide-react"
 
-const navigation = [
+type NavItem = {
+  name: string
+  href: string
+  hash?: string
+}
+
+const navigation: NavItem[] = [
   { name: "Home", href: "/#home", hash: "#home" },
   { name: "About", href: "/#about", hash: "#about" },
-  { name: "Products", href: "/#all-products", hash: "#all-products" },
-  { name: "Blog", href: "/#blog", hash: "#blog" },
+  { name: "Products", href: "/products" },
+  { name: "Blog", href: "/blog" },
   { name: "Contact", href: "/#contact", hash: "#contact" },
   { name: "Appoint", href: "/#appoint", hash: "#appoint" },
 ]
@@ -32,6 +38,14 @@ export function Navigation() {
     return () => window.removeEventListener("hashchange", updateHash)
   }, [])
 
+  const isActive = (item: NavItem) => {
+    if (item.hash) {
+      return pathname === "/" && currentHash === item.hash
+    }
+
+    return pathname === item.href
+  }
+
   return (
     <>
       <nav className="fixed top-0 z-50 w-full border-b bg-background/80 backdrop-blur-md">
@@ -44,12 +58,7 @@ export function Navigation() {
 
             <div className="hidden items-center space-x-1 md:flex">
               {navigation.map((item) => (
-                <Button
-                  key={item.name}
-                  variant={pathname === "/" && currentHash === item.hash ? "default" : "ghost"}
-                  className="rounded-full"
-                  asChild
-                >
+                <Button key={item.name} variant={isActive(item) ? "default" : "ghost"} className="rounded-full" asChild>
                   <Link href={item.href}>{item.name}</Link>
                 </Button>
               ))}
@@ -92,7 +101,7 @@ export function Navigation() {
                 }}
               >
                 <Button
-                  variant={pathname === "/" && currentHash === item.hash ? "default" : "ghost"}
+                  variant={isActive(item) ? "default" : "ghost"}
                   size="lg"
                   className="min-w-[200px] rounded-full bg-gradient-to-r from-blue-500/5 to-purple-500/5 px-8 py-6 text-2xl transition-all duration-300 hover:scale-105 hover:from-blue-500/20 hover:to-purple-500/20"
                   asChild


### PR DESCRIPTION
### Motivation
- Consolidate the portfolio so users can access hero, about, blog, products, contact and appointment content on a single scrollable page for a more cohesive SPA experience.
- Improve navigation usability by switching to in-page anchor/hash links with active-state tracking and smooth scrolling.

### Description
- Reworked `app/page.tsx` into an async SPA-style home route that composes the hero, about, blog, products, contact and appoint sections and fetches Zenn articles via `getZennArticles` and `getZennProductArticles`.
- Updated `components/navigation.tsx` to use hash anchors (e.g. `/#about`) and added a `hashchange` listener to track the active section for both desktop and mobile menus.
- Changed the Latest Products CTA in `components/latest-products.tsx` to point to the in-page products section (`/#all-products`) and added `scroll-behavior: smooth;` to `app/globals.css` for smooth anchor navigation.
- Preserved lazy loading for `CodeAnimation` and left the original per-route pages intact so both single-page and route-based navigation remain available.

### Testing
- Started the dev server with `pnpm dev` successfully and captured a Playwright screenshot of `http://127.0.0.1:3000/#about` to validate rendering.
- `pnpm build` failed in this environment due to external network issues (Google Fonts via `next/font` failed and Zenn feed fetches returned `ENETUNREACH`).
- `pnpm lint` could not complete because Next.js prompts for initial ESLint configuration interactively in this environment, causing the lint command to be blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb966aa6c832c840da549ee9f780b)