### PR TITLE
予約管理UI/メール文面の追加修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ BOOKING_PORTAL_BASE_URL=https://your-domain.com
     - Resend 設定時は予約完了メールを送信
     - attendees招待を有効にするには、Google Workspace の Domain-Wide Delegation + `GOOGLE_DELEGATED_USER_EMAIL` が必要
   - Supabase設定済みの場合は、予約後に `managePortal.url`（予約者専用ページURL）を返却
-  - Resendメール本文に `managePortal.url` と初期パスワードを同梱
+  - Resendメール本文に `managePortal.url` とパスワードを同梱
   - 予約者ページでの変更/キャンセルは、`gcp` モード時に Google Calendar イベントにも同期
 
 ## Supabaseテーブル（booking_portal）

--- a/app/api/bookings/manage/[id]/route.ts
+++ b/app/api/bookings/manage/[id]/route.ts
@@ -144,11 +144,21 @@ async function hasAllDayBusyEvent(accessToken: string, calendarId: string, date:
   })
 }
 
-async function sendResendMail(to: string, subject: string, html: string) {
+const MAIL_COMMON_FOOTER_HTML = `
+<hr style="margin:24px 0;border:none;border-top:1px solid #e5e7eb;" />
+<p style="color:#4b5563;font-size:13px;line-height:1.7;">
+このメールアドレスは送信専用です。<br />
+メールでのご連絡はinfo&#64;dokkiitech.comにお願いします<br />
+SNSでのご連絡は <a href="https://www.dokkiitech.com/contact">https://www.dokkiitech.com/contact</a> からお願いします。
+</p>
+`
+
+async function sendResendMail(to: string, subject: string, html: string, senderName = "dokkiitech予約管理システム") {
   const apiKey = process.env.RESEND_API_KEY
   const from = process.env.RESEND_FROM
   if (!apiKey || !from) return { sent: false, reason: "RESEND_API_KEY or RESEND_FROM missing" }
-  const fromHeader = from.includes("<") ? from : `dokkiitech予約管理システム <${from}>`
+  const fromAddress = from.includes("<") ? from.match(/<([^>]+)>/)?.[1] || from : from
+  const fromHeader = `${senderName} <${fromAddress}>`
 
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
@@ -160,7 +170,7 @@ async function sendResendMail(to: string, subject: string, html: string) {
       from: fromHeader,
       to: [to],
       subject,
-      html,
+      html: `${html}${MAIL_COMMON_FOOTER_HTML}`,
     }),
   })
   if (!response.ok) return { sent: false, reason: await response.text() }
@@ -316,7 +326,8 @@ export async function PATCH(
         ${meetUrl ? `<li>Meet URL：${meetUrl}</li>` : ""}
       </ul>
       <p>Googleカレンダーの予定にも変更内容が反映されます。</p>
-      `
+      `,
+      "dokkiitech予約管理システム予約変更センター"
     )
 
     return NextResponse.json({
@@ -388,7 +399,8 @@ export async function DELETE(
         <li>形式：${formatLine}</li>
       </ul>
       <p>Googleカレンダーの予定もキャンセルされます。</p>
-      `
+      `,
+      "dokkiitech予約管理システムキャンセル承りセンター"
     )
     return NextResponse.json({
       ok: true,

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -248,6 +248,15 @@ async function listAvailableSlots(accessToken: string, calendarId: string, date:
   })
 }
 
+const MAIL_COMMON_FOOTER_HTML = `
+<hr style="margin:24px 0;border:none;border-top:1px solid #e5e7eb;" />
+<p style="color:#4b5563;font-size:13px;line-height:1.7;">
+このメールアドレスは送信専用です。<br />
+メールでのご連絡はinfo&#64;dokkiitech.comにお願いします<br />
+SNSでのご連絡は <a href="https://www.dokkiitech.com/contact">https://www.dokkiitech.com/contact</a> からお願いします。
+</p>
+`
+
 async function sendResendMail(to: string, subject: string, html: string) {
   const apiKey = process.env.RESEND_API_KEY
   const from = process.env.RESEND_FROM
@@ -264,7 +273,7 @@ async function sendResendMail(to: string, subject: string, html: string) {
       from: fromHeader,
       to: [to],
       subject,
-      html,
+      html: `${html}${MAIL_COMMON_FOOTER_HTML}`,
     }),
   })
 

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -546,7 +546,7 @@ export async function POST(request: Request) {
       ${
         portal
           ? `<p><strong>予約者専用ページ:</strong> <a href="${manageUrl}">${manageUrl}</a></p>
-             <p><strong>初期パスワード:</strong> ${portal.initialPassword}</p>`
+             <p><strong>パスワード:</strong> ${portal.initialPassword}</p>`
           : "<p>予約者専用ページは現在利用できません。</p>"
       }
       <p>Googleカレンダーへの招待メールも別途送付されますのでご確認ください</p>

--- a/app/appointment/manage/[id]/page.tsx
+++ b/app/appointment/manage/[id]/page.tsx
@@ -83,6 +83,21 @@ export default function ManageBookingPage() {
 
   const showLocation = useMemo(() => record?.bookingType === "対面", [record?.bookingType])
 
+  const syncManageRecord = async (nextRecord: ManageRecord) => {
+    setRecord(nextRecord)
+    setSelectedDate(new Date(`${nextRecord.date}T00:00:00+09:00`))
+    setForm({
+      date: nextRecord.date,
+      timeSlot: nextRecord.timeSlot,
+      location: nextRecord.location || "",
+      company: nextRecord.company || "",
+      agenda: nextRecord.agenda,
+    })
+    await loadAvailability(nextRecord.date, nextRecord.timeSlot)
+    setStep("manage")
+    setMessage("")
+  }
+
   const verify = async (inputPassword?: string) => {
     const response = await fetch(`/api/bookings/manage/${params.id}/verify`, {
       method: "POST",
@@ -151,18 +166,17 @@ export default function ManageBookingPage() {
       return
     }
 
-    setRecord(checked.record)
-    setSelectedDate(new Date(`${checked.record.date}T00:00:00+09:00`))
-    setForm({
-      date: checked.record.date,
-      timeSlot: checked.record.timeSlot,
-      location: checked.record.location || "",
-      company: checked.record.company || "",
-      agenda: checked.record.agenda,
-    })
-    await loadAvailability(checked.record.date, checked.record.timeSlot)
-    setStep("manage")
-    setMessage("")
+    await syncManageRecord(checked.record)
+  }
+
+  const refreshAfterUpdate = async () => {
+    const checked = await verify(password)
+    if (!checked.ok || !checked.record) {
+      setMessage(checked.message || "最新の予約情報の取得に失敗しました。再ログインしてください。")
+      setStep("login")
+      return
+    }
+    await syncManageRecord(checked.record)
   }
 
   const onSetPassword = async () => {
@@ -274,8 +288,10 @@ export default function ManageBookingPage() {
             router.push("/")
             return
           }
-          setCompletion(null)
-          setMessage("")
+          void (async () => {
+            setCompletion(null)
+            await refreshAfterUpdate()
+          })()
         }}
       />
     )
@@ -354,7 +370,7 @@ export default function ManageBookingPage() {
             </div>
 
             <div className="rounded-xl border border-border bg-card px-4">
-              <Accordion type="single" collapsible defaultValue="manage-form">
+              <Accordion type="single" collapsible>
                 <AccordionItem value="manage-form" className="border-none">
                   <AccordionTrigger className="text-base hover:no-underline">変更やキャンセルはこちら</AccordionTrigger>
                   <AccordionContent className="space-y-4 pt-1">

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -57,19 +57,9 @@ export function Navigation() {
                 size="icon"
                 className="md:hidden rounded-full bg-gradient-to-r from-blue-500/10 to-purple-500/10 hover:from-blue-500/20 hover:to-purple-500/20 transition-all duration-300 hover:scale-105"
                 onClick={() => setIsOpen(!isOpen)}
+                aria-label={isOpen ? "メニューを閉じる" : "メニューを開く"}
               >
-                <div className="relative w-5 h-5">
-                  <Menu
-                    className={`w-5 h-5 absolute transition-all duration-300 ${
-                      isOpen ? "rotate-90 opacity-0" : "rotate-0 opacity-100"
-                    }`}
-                  />
-                  <X
-                    className={`w-5 h-5 absolute transition-all duration-300 ${
-                      isOpen ? "rotate-0 opacity-100" : "-rotate-90 opacity-0"
-                    }`}
-                  />
-                </div>
+                {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## 概要
マージ済みの予約管理改善に対する追加修正です。

## 対応内容
- カーテンUI（変更/キャンセルフォーム）をデフォルト未展開に変更
- 予約変更完了UIから「専用ページに戻る」押下時に最新予約情報を再取得し、日程/時間/内容を更新
- 予約変更メールの送信者名を `dokkiitech予約管理システム予約変更センター` に変更
- 予約キャンセルメールの送信者名を `dokkiitech予約管理システムキャンセル承りセンター` に変更
- 予約完了/変更/キャンセルの全メール本文末尾に共通案内文を追記
  - このメールアドレスは送信専用です
  - 連絡先メール: info@dokkiitech.com
  - SNS連絡先: https://www.dokkiitech.com/contact

## 変更ファイル
- app/appointment/manage/[id]/page.tsx
- app/api/bookings/manage/[id]/route.ts
- app/api/bookings/route.ts

## 動作確認
- npm run build: 成功