### PR TITLE
予約変更UI/同一日時変更禁止の再修正

### DIFF
--- a/app/api/bookings/manage/[id]/route.ts
+++ b/app/api/bookings/manage/[id]/route.ts
@@ -217,6 +217,13 @@ export async function PATCH(
     const nextAgenda = body.agenda ? String(body.agenda) : checked.record.agenda
     const nextCompany = body.company !== undefined ? String(body.company || "") : checked.record.company
 
+    if (nextDate === checked.record.date && nextTimeSlot === checked.record.time_slot) {
+      return NextResponse.json(
+        { ok: false, message: "現在と同じ日時には変更できません。別の時間を選択してください。" },
+        { status: 400 }
+      )
+    }
+
     if (isPastSlot(nextDate, nextTimeSlot)) {
       return NextResponse.json(
         { ok: false, message: "過去の時間帯は予約できません。未来の時間を選択してください。" },

--- a/app/api/bookings/manage/[id]/route.ts
+++ b/app/api/bookings/manage/[id]/route.ts
@@ -153,11 +153,21 @@ SNSでのご連絡は <a href="https://www.dokkiitech.com/contact">https://www.d
 </p>
 `
 
-async function sendResendMail(to: string, subject: string, html: string, senderName = "dokkiitech予約管理システム") {
+const UPDATE_FROM_ADDRESS = "reappointment@dokkiitech.dev"
+const CANCEL_FROM_ADDRESS = "unappointment@dokkiitech.dev"
+
+async function sendResendMail(
+  to: string,
+  subject: string,
+  html: string,
+  senderName = "dokkiitech予約管理システム",
+  fromAddressOverride?: string
+) {
   const apiKey = process.env.RESEND_API_KEY
   const from = process.env.RESEND_FROM
   if (!apiKey || !from) return { sent: false, reason: "RESEND_API_KEY or RESEND_FROM missing" }
-  const fromAddress = from.includes("<") ? from.match(/<([^>]+)>/)?.[1] || from : from
+  const defaultFromAddress = from.includes("<") ? from.match(/<([^>]+)>/)?.[1] || from : from
+  const fromAddress = fromAddressOverride || defaultFromAddress
   const fromHeader = `${senderName} <${fromAddress}>`
 
   const response = await fetch("https://api.resend.com/emails", {
@@ -334,7 +344,8 @@ export async function PATCH(
       </ul>
       <p>Googleカレンダーの予定にも変更内容が反映されます。</p>
       `,
-      "dokkiitech予約管理システム予約変更センター"
+      "dokkiitech予約管理システム予約変更センター",
+      UPDATE_FROM_ADDRESS
     )
 
     return NextResponse.json({
@@ -407,7 +418,8 @@ export async function DELETE(
       </ul>
       <p>Googleカレンダーの予定もキャンセルされます。</p>
       `,
-      "dokkiitech予約管理システムキャンセル承りセンター"
+      "dokkiitech予約管理システムキャンセル承りセンター",
+      CANCEL_FROM_ADDRESS
     )
     return NextResponse.json({
       ok: true,

--- a/app/appointment/manage/[id]/page.tsx
+++ b/app/appointment/manage/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function ManageBookingPage() {
       company: nextRecord.company || "",
       agenda: nextRecord.agenda,
     })
-    await loadAvailability(nextRecord.date, nextRecord.timeSlot)
+    await loadAvailability(nextRecord.date)
     setStep("manage")
     setMessage("")
   }
@@ -133,7 +133,7 @@ export default function ManageBookingPage() {
     bootstrap()
   }, [token, params.id])
 
-  const loadAvailability = async (dateStr: string, currentTimeSlot?: string) => {
+  const loadAvailability = async (dateStr: string) => {
     setLoadingSlots(true)
     try {
       const response = await fetch(`/api/bookings?date=${dateStr}&bookingType=${encodeURIComponent(record?.bookingType || "meet")}`)
@@ -141,12 +141,10 @@ export default function ManageBookingPage() {
       const fromApi = response.ok && json.ok && Array.isArray(json.slots)
         ? (json.slots as string[])
         : buildFallbackSlots(dateStr, record?.bookingType || "meet")
-      const merged = currentTimeSlot && !fromApi.includes(currentTimeSlot) ? [currentTimeSlot, ...fromApi] : fromApi
-      setAvailableSlots(Array.from(new Set(merged)))
+      setAvailableSlots(Array.from(new Set(fromApi)))
     } catch {
       const fallback = buildFallbackSlots(dateStr, record?.bookingType || "meet")
-      const merged = currentTimeSlot && !fallback.includes(currentTimeSlot) ? [currentTimeSlot, ...fallback] : fallback
-      setAvailableSlots(Array.from(new Set(merged)))
+      setAvailableSlots(Array.from(new Set(fallback)))
     } finally {
       setLoadingSlots(false)
     }
@@ -156,7 +154,7 @@ export default function ManageBookingPage() {
     if (!selectedDate || step !== "manage") return
     const dateStr = format(selectedDate, "yyyy-MM-dd")
     setForm((prev) => ({ ...prev, date: dateStr, timeSlot: "" }))
-    void loadAvailability(dateStr, record?.timeSlot)
+    void loadAvailability(dateStr)
   }, [selectedDate, step, record?.timeSlot])
 
   const onLogin = async () => {


### PR DESCRIPTION
## 概要
PR作り直し版です。

## 変更内容
- 予約変更フォームの空き枠一覧に「現在の自分の予約枠」を混ぜないよう修正
- API側でも、現在と同じ日時への変更リクエストを 400 で拒否
  - メッセージ: 現在と同じ日時には変更できません。別の時間を選択してください。

## 変更ファイル
- app/appointment/manage/[id]/page.tsx
- app/api/bookings/manage/[id]/route.ts

## 確認
- npm run build 成功