### PR TITLE
Add admin page for all bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ BOOKING_SLOT_END_HOUR=24
 RESEND_API_KEY=
 RESEND_FROM=booking@your-domain.com
 
+# Discord webhook（コンシェルジュ通知）
+DISCORD_CONCIERGE_WEBHOOK_URL=
+BOOKING_ADMIN_BASE_URL=https://your-domain.com
+
 # 予約者専用ページ（Supabase）
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
@@ -107,6 +111,7 @@ BOOKING_PORTAL_BASE_URL=https://your-domain.com
     - `meet` の場合は Meet URL 自動発行
     - `対面` の場合は `location` をイベント場所に設定
     - Resend 設定時は予約完了メールを送信
+    - Discord webhook 設定時は、コンシェルジュ名義のリッチ通知を Discord に送信
     - attendees招待を有効にするには、Google Workspace の Domain-Wide Delegation + `GOOGLE_DELEGATED_USER_EMAIL` が必要
   - Supabase設定済みの場合は、予約後に `managePortal.url`（予約者専用ページURL）を返却
   - Resendメール本文に `managePortal.url` とパスワードを同梱

--- a/app/api/bookings/admin/route.ts
+++ b/app/api/bookings/admin/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server"
+import { listBookingPortals, type BookingPortalStatus } from "@/lib/booking-portal"
+
+export const runtime = "nodejs"
+
+function getAdminKey(): string {
+  const key = process.env.BOOKING_ADMIN_KEY
+  if (!key) {
+    throw new Error("BOOKING_ADMIN_KEY is not configured")
+  }
+  return key
+}
+
+function isValidStatus(value: string | null): value is BookingPortalStatus {
+  return value === "active" || value === "canceled" || value === "expired"
+}
+
+function resolveStatus(status: BookingPortalStatus, expiresAt: string): BookingPortalStatus {
+  if (status !== "active") return status
+  return new Date(expiresAt).getTime() < Date.now() ? "expired" : "active"
+}
+
+export async function GET(request: Request) {
+  try {
+    const configuredKey = getAdminKey()
+    const providedKey = request.headers.get("x-booking-admin-key") || ""
+
+    if (providedKey !== configuredKey) {
+      return NextResponse.json({ ok: false, message: "管理者認証に失敗しました。" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const date = searchParams.get("date") || undefined
+    const statusParam = searchParams.get("status")
+    const status = isValidStatus(statusParam) ? statusParam : "all"
+
+    const records = await listBookingPortals({ date })
+    const normalizedRecords = records.map((record) => ({
+      ...record,
+      status: resolveStatus(record.status, record.expires_at),
+    }))
+    const filteredRecords =
+      status === "all" ? normalizedRecords : normalizedRecords.filter((record) => record.status === status)
+
+    return NextResponse.json({
+      ok: true,
+      records: filteredRecords.map((record) => ({
+        id: record.id,
+        bookingId: record.booking_id,
+        name: record.name,
+        email: record.email,
+        company: record.company,
+        bookingType: record.booking_type,
+        date: record.date,
+        timeSlot: record.time_slot,
+        agenda: record.agenda,
+        location: record.location,
+        status: record.status,
+        calendarEventUrl: record.calendar_event_url,
+        meetUrl: record.meet_url,
+        expiresAt: record.expires_at,
+        createdAt: record.created_at,
+        updatedAt: record.updated_at,
+      })),
+    })
+  } catch (error) {
+    const message = error instanceof Error && error.message.includes("BOOKING_ADMIN_KEY")
+      ? "管理画面キーが未設定です。"
+      : "予約一覧の取得に失敗しました。"
+    return NextResponse.json({ ok: false, message, error: String(error) }, { status: 500 })
+  }
+}

--- a/app/api/bookings/admin/route.ts
+++ b/app/api/bookings/admin/route.ts
@@ -3,14 +3,6 @@ import { listBookingPortals, type BookingPortalStatus } from "@/lib/booking-port
 
 export const runtime = "nodejs"
 
-function getAdminKey(): string {
-  const key = process.env.BOOKING_ADMIN_KEY
-  if (!key) {
-    throw new Error("BOOKING_ADMIN_KEY is not configured")
-  }
-  return key
-}
-
 function isValidStatus(value: string | null): value is BookingPortalStatus {
   return value === "active" || value === "canceled" || value === "expired"
 }
@@ -22,13 +14,6 @@ function resolveStatus(status: BookingPortalStatus, expiresAt: string): BookingP
 
 export async function GET(request: Request) {
   try {
-    const configuredKey = getAdminKey()
-    const providedKey = request.headers.get("x-booking-admin-key") || ""
-
-    if (providedKey !== configuredKey) {
-      return NextResponse.json({ ok: false, message: "管理者認証に失敗しました。" }, { status: 401 })
-    }
-
     const { searchParams } = new URL(request.url)
     const date = searchParams.get("date") || undefined
     const statusParam = searchParams.get("status")
@@ -64,9 +49,6 @@ export async function GET(request: Request) {
       })),
     })
   } catch (error) {
-    const message = error instanceof Error && error.message.includes("BOOKING_ADMIN_KEY")
-      ? "管理画面キーが未設定です。"
-      : "予約一覧の取得に失敗しました。"
-    return NextResponse.json({ ok: false, message, error: String(error) }, { status: 500 })
+    return NextResponse.json({ ok: false, message: "予約一覧の取得に失敗しました。", error: String(error) }, { status: 500 })
   }
 }

--- a/app/api/bookings/manage/[id]/route.ts
+++ b/app/api/bookings/manage/[id]/route.ts
@@ -1,6 +1,7 @@
 import { createSign } from "crypto"
 import { NextResponse } from "next/server"
 import { cancelPortalBooking, updatePortalBooking, verifyPortalAccess } from "@/lib/booking-portal"
+import { sendDiscordConciergeNotification } from "@/lib/discord-concierge"
 
 const DEFAULT_TIMEZONE = process.env.BOOKING_TIMEZONE || "Asia/Tokyo"
 const DEFAULT_OFFSET = process.env.BOOKING_TIMEZONE_OFFSET || "+09:00"
@@ -349,6 +350,24 @@ export async function PATCH(
       UPDATE_FROM_ADDRESS
     )
 
+    const discord = await sendDiscordConciergeNotification("updated", {
+      bookingId: checked.record.booking_id,
+      name: checked.record.name,
+      email: checked.record.email,
+      company: nextCompany,
+      bookingType: nextBookingType,
+      date: nextDate,
+      timeSlot: nextTimeSlot,
+      agenda: nextAgenda,
+      location: nextLocation,
+      status: "予約変更",
+      meetUrl,
+      calendarEventUrl,
+    }).catch((error) => ({ sent: false, reason: String(error) }))
+    if (!discord.sent) {
+      console.error("Failed to send Discord concierge notification (update):", discord.reason)
+    }
+
     return NextResponse.json({
       ok: true,
       message: "予約情報を更新しました。",
@@ -423,6 +442,25 @@ export async function DELETE(
       "dokkiitech予約管理システムキャンセル承りセンター",
       CANCEL_FROM_ADDRESS
     )
+
+    const discord = await sendDiscordConciergeNotification("canceled", {
+      bookingId: checked.record.booking_id,
+      name: checked.record.name,
+      email: checked.record.email,
+      company: checked.record.company,
+      bookingType: checked.record.booking_type,
+      date: checked.record.date,
+      timeSlot: checked.record.time_slot,
+      agenda: checked.record.agenda,
+      location: checked.record.location,
+      status: "キャンセル",
+      meetUrl: checked.record.meet_url,
+      calendarEventUrl: checked.record.calendar_event_url,
+    }).catch((error) => ({ sent: false, reason: String(error) }))
+    if (!discord.sent) {
+      console.error("Failed to send Discord concierge notification (cancel):", discord.reason)
+    }
+
     return NextResponse.json({
       ok: true,
       message: "予約をキャンセルしました。",

--- a/app/api/bookings/manage/[id]/route.ts
+++ b/app/api/bookings/manage/[id]/route.ts
@@ -337,6 +337,7 @@ export async function PATCH(
       <p>${salutation}</p>
       <p>お打ち合わせの予約内容を変更しました。下記の内容で更新されました。</p>
       <ul>
+        <li>予約番号：${checked.record.booking_id}</li>
         <li>日程：${dateJp}</li>
         <li>時刻：${nextTimeSlot} - ${endTime}</li>
         <li>形式：${formatLine}</li>
@@ -412,6 +413,7 @@ export async function DELETE(
       <p>${salutation}</p>
       <p>お打ち合わせのご予約をキャンセルしました。下記の内容がキャンセル対象です。</p>
       <ul>
+        <li>予約番号：${checked.record.booking_id}</li>
         <li>日程：${dateJp}</li>
         <li>時刻：${checked.record.time_slot} - ${endTime}</li>
         <li>形式：${formatLine}</li>

--- a/app/api/bookings/manage/[id]/verify/route.ts
+++ b/app/api/bookings/manage/[id]/verify/route.ts
@@ -20,6 +20,7 @@ export async function POST(
       ok: true,
       record: {
         id: checked.record.id,
+        bookingId: checked.record.booking_id,
         name: checked.record.name,
         email: checked.record.email,
         company: checked.record.company,

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,7 +1,7 @@
 import { createSign } from "crypto"
 import { NextResponse } from "next/server"
 import { bookingSchema } from "@/lib/booking"
-import { createBookingPortal } from "@/lib/booking-portal"
+import { createBookingPortal, generateBookingReference } from "@/lib/booking-portal"
 
 export const runtime = "nodejs"
 
@@ -368,6 +368,7 @@ export async function POST(request: Request) {
 
     const payload = parsed.data
     const mode = getMode()
+    const bookingReference = await generateBookingReference()
 
     if (isInPersonLeadTimeInvalid(payload.bookingType, payload.date)) {
       return NextResponse.json(
@@ -395,7 +396,7 @@ export async function POST(request: Request) {
       let portalError: string | null = null
       try {
         portal = await createBookingPortal({
-          bookingId: `mock_${Date.now()}`,
+          bookingId: bookingReference,
           name: payload.name,
           email: payload.email,
           company: payload.company,
@@ -413,7 +414,7 @@ export async function POST(request: Request) {
       return NextResponse.json({
         ok: true,
         mode,
-        bookingId: `mock_${Date.now()}`,
+        bookingId: bookingReference,
         message: "予約リクエストを受け付けました（モック処理）。",
         request: payload,
         contract: {
@@ -508,7 +509,7 @@ export async function POST(request: Request) {
     let portalError: string | null = null
     try {
       portal = await createBookingPortal({
-        bookingId: event.id || `evt_${Date.now()}`,
+        bookingId: bookingReference,
         name: payload.name,
         email: payload.email,
         company: payload.company,
@@ -538,6 +539,7 @@ export async function POST(request: Request) {
       <p>${salutation}</p>
       <p>お打ち合わせのご予約ありがとうございます。下記の内容で受け付けました。</p>
       <ul>
+        <li>予約番号：${bookingReference}</li>
         <li>日程：${dateJp}</li>
         <li>時刻：${payload.timeSlot} - ${endTime}</li>
         <li>形式：${formatLine}</li>
@@ -558,7 +560,7 @@ export async function POST(request: Request) {
       ok: true,
       mode,
       message: "予約を確定しました。Google Calendar 招待と完了メールを送信しました。",
-      bookingId: event.id,
+      bookingId: bookingReference,
       calendarEventUrl: event.htmlLink,
       meetUrl: event.hangoutLink,
       location: event.location,

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -2,6 +2,7 @@ import { createSign } from "crypto"
 import { NextResponse } from "next/server"
 import { bookingSchema } from "@/lib/booking"
 import { createBookingPortal, generateBookingReference } from "@/lib/booking-portal"
+import { sendDiscordConciergeNotification } from "@/lib/discord-concierge"
 
 export const runtime = "nodejs"
 
@@ -411,6 +412,22 @@ export async function POST(request: Request) {
         portalError = String(error)
       }
 
+      const discord = await sendDiscordConciergeNotification("created", {
+        bookingId: bookingReference,
+        name: payload.name,
+        email: payload.email,
+        company: payload.company,
+        bookingType: payload.bookingType,
+        date: payload.date,
+        timeSlot: payload.timeSlot,
+        agenda: payload.agenda,
+        location: payload.location,
+        status: "新規受付",
+      }).catch((error) => ({ sent: false, reason: String(error) }))
+      if (!discord.sent) {
+        console.error("Failed to send Discord concierge notification (mock):", discord.reason)
+      }
+
       return NextResponse.json({
         ok: true,
         mode,
@@ -555,6 +572,24 @@ export async function POST(request: Request) {
       <p>当日はどうぞよろしくお願い致します。</p>
       `
     )
+
+    const discord = await sendDiscordConciergeNotification("created", {
+      bookingId: bookingReference,
+      name: payload.name,
+      email: payload.email,
+      company: payload.company,
+      bookingType: payload.bookingType,
+      date: payload.date,
+      timeSlot: payload.timeSlot,
+      agenda: payload.agenda,
+      location: payload.location,
+      status: "予約確定",
+      meetUrl: event.hangoutLink,
+      calendarEventUrl: event.htmlLink,
+    }).catch((error) => ({ sent: false, reason: String(error) }))
+    if (!discord.sent) {
+      console.error("Failed to send Discord concierge notification (gcp):", discord.reason)
+    }
 
     return NextResponse.json({
       ok: true,

--- a/app/appointment/admin/page.tsx
+++ b/app/appointment/admin/page.tsx
@@ -1,0 +1,312 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+type BookingStatus = "active" | "canceled" | "expired"
+
+interface AdminBookingRecord {
+  id: string
+  bookingId: string
+  name: string
+  email: string
+  company?: string | null
+  bookingType: "meet" | "対面"
+  date: string
+  timeSlot: string
+  agenda: string
+  location?: string | null
+  status: BookingStatus
+  calendarEventUrl?: string | null
+  meetUrl?: string | null
+  expiresAt: string
+  createdAt: string
+  updatedAt: string
+}
+
+function formatBookingDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00+09:00`)
+  if (Number.isNaN(parsed.getTime())) return date
+  return format(parsed, "yyyy年M月d日(E)", { locale: ja })
+}
+
+function formatDateTime(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return format(parsed, "yyyy/MM/dd HH:mm")
+}
+
+function formatBookingType(value: "meet" | "対面"): string {
+  return value === "meet" ? "Google Meet" : "対面"
+}
+
+function formatStatus(value: BookingStatus): string {
+  if (value === "active") return "有効"
+  if (value === "canceled") return "キャンセル"
+  return "期限切れ"
+}
+
+function getStatusClassName(value: BookingStatus): string {
+  if (value === "active") return "bg-emerald-500/15 text-emerald-200 border-emerald-400/30"
+  if (value === "canceled") return "bg-rose-500/15 text-rose-200 border-rose-400/30"
+  return "bg-slate-500/15 text-slate-200 border-slate-300/30"
+}
+
+export default function AppointmentAdminPage() {
+  const [adminKey, setAdminKey] = useState("")
+  const [authenticated, setAuthenticated] = useState(false)
+  const [records, setRecords] = useState<AdminBookingRecord[]>([])
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState("")
+  const [filters, setFilters] = useState({
+    date: "",
+    status: "all",
+    query: "",
+  })
+
+  const loadBookings = async (nextFilters = filters, key = adminKey) => {
+    setLoading(true)
+    setMessage("")
+    try {
+      const params = new URLSearchParams()
+      if (nextFilters.date) params.set("date", nextFilters.date)
+      if (nextFilters.status !== "all") params.set("status", nextFilters.status)
+
+      const response = await fetch(`/api/bookings/admin?${params.toString()}`, {
+        headers: {
+          "x-booking-admin-key": key,
+        },
+      })
+      const json = await response.json()
+      if (!response.ok || !json.ok) {
+        setAuthenticated(false)
+        setRecords([])
+        setMessage(json.message || "予約一覧を取得できませんでした。")
+        return
+      }
+
+      setAuthenticated(true)
+      setRecords(Array.isArray(json.records) ? (json.records as AdminBookingRecord[]) : [])
+    } catch {
+      setMessage("通信エラーが発生しました。時間をおいて再度お試しください。")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const filteredRecords = useMemo(() => {
+    const keyword = filters.query.trim().toLowerCase()
+    if (!keyword) return records
+    return records.filter((record) =>
+      [record.name, record.email, record.company || "", record.agenda, record.bookingId]
+        .join(" ")
+        .toLowerCase()
+        .includes(keyword)
+    )
+  }, [filters.query, records])
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+        <div className="rounded-3xl border border-border bg-card/95 p-6 shadow-sm sm:p-8">
+          <div className="flex flex-col gap-3 border-b border-border pb-6 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm text-cyan-300">管理者向け</p>
+              <h1 className="text-3xl font-bold">予約一覧管理</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                全予約の確認と、日付・ステータスでの絞り込みができます。
+              </p>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              表示件数: <span className="font-medium text-foreground">{filteredRecords.length}</span>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-[280px_minmax(0,1fr)]">
+            <aside className="rounded-2xl border border-border bg-background/60 p-4">
+              <div>
+                <Label htmlFor="adminKey">管理画面キー</Label>
+                <Input
+                  id="adminKey"
+                  type="password"
+                  value={adminKey}
+                  onChange={(event) => setAdminKey(event.target.value)}
+                  placeholder="BOOKING_ADMIN_KEY"
+                  className="mt-2"
+                />
+              </div>
+
+              <div className="mt-4 space-y-4">
+                <div>
+                  <Label htmlFor="filterDate">日付で絞り込み</Label>
+                  <Input
+                    id="filterDate"
+                    type="date"
+                    value={filters.date}
+                    onChange={(event) => setFilters((prev) => ({ ...prev, date: event.target.value }))}
+                    className="mt-2"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="filterStatus">ステータス</Label>
+                  <select
+                    id="filterStatus"
+                    value={filters.status}
+                    onChange={(event) => setFilters((prev) => ({ ...prev, status: event.target.value }))}
+                    className="mt-2 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  >
+                    <option value="all">すべて</option>
+                    <option value="active">有効</option>
+                    <option value="canceled">キャンセル</option>
+                    <option value="expired">期限切れ</option>
+                  </select>
+                </div>
+
+                <div>
+                  <Label htmlFor="filterQuery">キーワード検索</Label>
+                  <Input
+                    id="filterQuery"
+                    value={filters.query}
+                    onChange={(event) => setFilters((prev) => ({ ...prev, query: event.target.value }))}
+                    placeholder="予約者名 / メール / 会社名"
+                    className="mt-2"
+                  />
+                </div>
+              </div>
+
+              <div className="mt-5 flex flex-col gap-2">
+                <Button onClick={() => void loadBookings()} disabled={loading || !adminKey}>
+                  {loading ? "読み込み中..." : authenticated ? "再読み込み" : "認証して一覧表示"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    const resetFilters = { date: "", status: "all", query: "" }
+                    setFilters(resetFilters)
+                    if (authenticated) {
+                      void loadBookings(resetFilters)
+                    }
+                  }}
+                >
+                  絞り込みをリセット
+                </Button>
+              </div>
+
+              {message && <p className="mt-4 text-sm text-rose-300 whitespace-pre-line">{message}</p>}
+            </aside>
+
+            <div className="min-w-0">
+              <div className="hidden overflow-hidden rounded-2xl border border-border md:block">
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-border text-sm">
+                    <thead className="bg-background/80">
+                      <tr className="text-left text-muted-foreground">
+                        <th className="px-4 py-3 font-medium">日時</th>
+                        <th className="px-4 py-3 font-medium">予約者</th>
+                        <th className="px-4 py-3 font-medium">方式</th>
+                        <th className="px-4 py-3 font-medium">ステータス</th>
+                        <th className="px-4 py-3 font-medium">詳細</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {filteredRecords.map((record) => (
+                        <tr key={record.id} className="align-top">
+                          <td className="px-4 py-4">
+                            <div className="font-medium">{formatBookingDate(record.date)}</div>
+                            <div className="text-muted-foreground">{record.timeSlot}</div>
+                          </td>
+                          <td className="px-4 py-4">
+                            <div className="font-medium">{record.name}</div>
+                            <div className="text-muted-foreground">{record.email}</div>
+                            {record.company && <div className="text-muted-foreground">{record.company}</div>}
+                          </td>
+                          <td className="px-4 py-4">
+                            <div>{formatBookingType(record.bookingType)}</div>
+                            {record.location && <div className="text-muted-foreground">{record.location}</div>}
+                          </td>
+                          <td className="px-4 py-4">
+                            <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
+                              {formatStatus(record.status)}
+                            </span>
+                          </td>
+                          <td className="px-4 py-4">
+                            <div className="space-y-1">
+                              <div className="line-clamp-3 text-muted-foreground">{record.agenda}</div>
+                              <div className="text-xs text-muted-foreground">作成: {formatDateTime(record.createdAt)}</div>
+                              <div className="text-xs text-muted-foreground">更新: {formatDateTime(record.updatedAt)}</div>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                      {!loading && filteredRecords.length === 0 && (
+                        <tr>
+                          <td colSpan={5} className="px-4 py-10 text-center text-muted-foreground">
+                            表示できる予約はありません。
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="space-y-4 md:hidden">
+                {filteredRecords.map((record) => (
+                  <article key={record.id} className="rounded-2xl border border-border bg-background/60 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h2 className="font-semibold">{record.name}</h2>
+                        <p className="text-sm text-muted-foreground">{record.email}</p>
+                      </div>
+                      <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
+                        {formatStatus(record.status)}
+                      </span>
+                    </div>
+                    <dl className="mt-4 space-y-2 text-sm">
+                      <div className="flex items-start justify-between gap-4">
+                        <dt className="text-muted-foreground">日時</dt>
+                        <dd className="text-right">{formatBookingDate(record.date)} {record.timeSlot}</dd>
+                      </div>
+                      <div className="flex items-start justify-between gap-4">
+                        <dt className="text-muted-foreground">方式</dt>
+                        <dd className="text-right">{formatBookingType(record.bookingType)}</dd>
+                      </div>
+                      {record.location && (
+                        <div className="flex items-start justify-between gap-4">
+                          <dt className="text-muted-foreground">場所</dt>
+                          <dd className="text-right">{record.location}</dd>
+                        </div>
+                      )}
+                      {record.company && (
+                        <div className="flex items-start justify-between gap-4">
+                          <dt className="text-muted-foreground">会社名</dt>
+                          <dd className="text-right">{record.company}</dd>
+                        </div>
+                      )}
+                      <div>
+                        <dt className="text-muted-foreground">相談内容</dt>
+                        <dd className="mt-1 whitespace-pre-wrap text-sm">{record.agenda}</dd>
+                      </div>
+                    </dl>
+                  </article>
+                ))}
+
+                {!loading && filteredRecords.length === 0 && (
+                  <div className="rounded-2xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+                    表示できる予約はありません。
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/appointment/admin/page.tsx
+++ b/app/appointment/admin/page.tsx
@@ -3,9 +3,19 @@
 import { useEffect, useMemo, useState } from "react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 type BookingStatus = "active" | "canceled" | "expired"
 
@@ -26,6 +36,12 @@ interface AdminBookingRecord {
   expiresAt: string
   createdAt: string
   updatedAt: string
+}
+
+interface SearchFilters {
+  date: string
+  status: "all" | BookingStatus
+  query: string
 }
 
 function formatBookingDate(date: string): string {
@@ -51,16 +67,23 @@ function formatStatus(value: BookingStatus): string {
 }
 
 function getStatusClassName(value: BookingStatus): string {
-  if (value === "active") return "bg-emerald-500/15 text-emerald-200 border-emerald-400/30"
-  if (value === "canceled") return "bg-rose-500/15 text-rose-200 border-rose-400/30"
-  return "bg-slate-500/15 text-slate-200 border-slate-300/30"
+  if (value === "active") return "border-emerald-400/30 bg-emerald-500/15 text-emerald-200"
+  if (value === "canceled") return "border-rose-400/30 bg-rose-500/15 text-rose-200"
+  return "border-slate-300/30 bg-slate-500/15 text-slate-200"
+}
+
+function sameDate(date: Date | undefined, key: string): boolean {
+  if (!date) return false
+  return format(date, "yyyy-MM-dd") === key
 }
 
 export default function AppointmentAdminPage() {
   const [records, setRecords] = useState<AdminBookingRecord[]>([])
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState("")
-  const [filters, setFilters] = useState({
+  const [selectedRecord, setSelectedRecord] = useState<AdminBookingRecord | null>(null)
+  const [calendarDate, setCalendarDate] = useState<Date | undefined>(new Date())
+  const [filters, setFilters] = useState<SearchFilters>({
     date: "",
     status: "all",
     query: "",
@@ -90,20 +113,23 @@ export default function AppointmentAdminPage() {
     }
   }
 
+  useEffect(() => {
+    void loadBookings()
+  }, [])
+
   const filteredRecords = useMemo(() => {
     const keyword = filters.query.trim().toLowerCase()
     if (!keyword) return records
     return records.filter((record) =>
-      [record.name, record.email, record.company || "", record.agenda, record.bookingId]
-        .join(" ")
-        .toLowerCase()
-        .includes(keyword)
+      [record.bookingId, record.name].join(" ").toLowerCase().includes(keyword)
     )
   }, [filters.query, records])
 
-  useEffect(() => {
-    void loadBookings()
-  }, [])
+  const selectedDateKey = calendarDate ? format(calendarDate, "yyyy-MM-dd") : ""
+  const calendarRecords = useMemo(
+    () => filteredRecords.filter((record) => record.date === selectedDateKey),
+    [filteredRecords, selectedDateKey]
+  )
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -112,9 +138,9 @@ export default function AppointmentAdminPage() {
           <div className="flex flex-col gap-3 border-b border-border pb-6 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <p className="text-sm text-cyan-300">管理者向け</p>
-              <h1 className="text-3xl font-bold">予約一覧管理</h1>
+              <h1 className="text-3xl font-bold">予約管理</h1>
               <p className="mt-2 text-sm text-muted-foreground">
-                全予約の確認と、日付・ステータスでの絞り込みができます。
+                一覧表示とカレンダービューを切り替えながら、予約番号ベースで確認できます。
               </p>
             </div>
             <div className="text-sm text-muted-foreground">
@@ -122,107 +148,110 @@ export default function AppointmentAdminPage() {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-4 lg:grid-cols-[280px_minmax(0,1fr)]">
-            <aside className="rounded-2xl border border-border bg-background/60 p-4">
-              <div className="space-y-4">
-                <div>
-                  <Label htmlFor="filterDate">日付で絞り込み</Label>
-                  <Input
-                    id="filterDate"
-                    type="date"
-                    value={filters.date}
-                    onChange={(event) => setFilters((prev) => ({ ...prev, date: event.target.value }))}
-                    className="mt-2"
-                  />
+          <Accordion type="single" collapsible className="mt-6 rounded-2xl border border-border bg-background/60 px-4">
+            <AccordionItem value="search" className="border-none">
+              <AccordionTrigger className="py-4 text-base">検索・絞り込み</AccordionTrigger>
+              <AccordionContent className="pb-4">
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div>
+                    <Label htmlFor="filterQuery">予約番号 / 予約者名</Label>
+                    <Input
+                      id="filterQuery"
+                      value={filters.query}
+                      onChange={(event) => setFilters((prev) => ({ ...prev, query: event.target.value }))}
+                      placeholder="例: 123456789 / 山田"
+                      className="mt-2"
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="filterDate">日付</Label>
+                    <Input
+                      id="filterDate"
+                      type="date"
+                      value={filters.date}
+                      onChange={(event) => setFilters((prev) => ({ ...prev, date: event.target.value }))}
+                      className="mt-2"
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="filterStatus">ステータス</Label>
+                    <select
+                      id="filterStatus"
+                      value={filters.status}
+                      onChange={(event) =>
+                        setFilters((prev) => ({ ...prev, status: event.target.value as SearchFilters["status"] }))
+                      }
+                      className="mt-2 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="all">すべて</option>
+                      <option value="active">有効</option>
+                      <option value="canceled">キャンセル</option>
+                      <option value="expired">期限切れ</option>
+                    </select>
+                  </div>
                 </div>
 
-                <div>
-                  <Label htmlFor="filterStatus">ステータス</Label>
-                  <select
-                    id="filterStatus"
-                    value={filters.status}
-                    onChange={(event) => setFilters((prev) => ({ ...prev, status: event.target.value }))}
-                    className="mt-2 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                  <Button onClick={() => void loadBookings()} disabled={loading}>
+                    {loading ? "読み込み中..." : "検索する"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      const resetFilters: SearchFilters = { date: "", status: "all", query: "" }
+                      setFilters(resetFilters)
+                      void loadBookings(resetFilters)
+                    }}
                   >
-                    <option value="all">すべて</option>
-                    <option value="active">有効</option>
-                    <option value="canceled">キャンセル</option>
-                    <option value="expired">期限切れ</option>
-                  </select>
+                    リセット
+                  </Button>
                 </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
 
-                <div>
-                  <Label htmlFor="filterQuery">キーワード検索</Label>
-                  <Input
-                    id="filterQuery"
-                    value={filters.query}
-                    onChange={(event) => setFilters((prev) => ({ ...prev, query: event.target.value }))}
-                    placeholder="予約者名 / メール / 会社名"
-                    className="mt-2"
-                  />
-                </div>
-              </div>
+          {message && <p className="mt-4 whitespace-pre-line text-sm text-rose-300">{message}</p>}
 
-              <div className="mt-5 flex flex-col gap-2">
-                <Button onClick={() => void loadBookings()} disabled={loading}>
-                  {loading ? "読み込み中..." : "再読み込み"}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    const resetFilters = { date: "", status: "all", query: "" }
-                    setFilters(resetFilters)
-                    void loadBookings(resetFilters)
-                  }}
-                >
-                  絞り込みをリセット
-                </Button>
-              </div>
+          <Tabs defaultValue="list" className="mt-6">
+            <TabsList>
+              <TabsTrigger value="list">一覧表示</TabsTrigger>
+              <TabsTrigger value="calendar">カレンダービュー</TabsTrigger>
+            </TabsList>
 
-              {message && <p className="mt-4 text-sm text-rose-300 whitespace-pre-line">{message}</p>}
-            </aside>
-
-            <div className="min-w-0">
+            <TabsContent value="list" className="mt-4">
               <div className="hidden overflow-hidden rounded-2xl border border-border md:block">
                 <div className="overflow-x-auto">
                   <table className="min-w-full divide-y divide-border text-sm">
                     <thead className="bg-background/80">
                       <tr className="text-left text-muted-foreground">
+                        <th className="px-4 py-3 font-medium">予約番号</th>
                         <th className="px-4 py-3 font-medium">日時</th>
                         <th className="px-4 py-3 font-medium">予約者</th>
                         <th className="px-4 py-3 font-medium">方式</th>
                         <th className="px-4 py-3 font-medium">ステータス</th>
-                        <th className="px-4 py-3 font-medium">詳細</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-border">
                       {filteredRecords.map((record) => (
-                        <tr key={record.id} className="align-top">
+                        <tr
+                          key={record.id}
+                          className="cursor-pointer transition-colors hover:bg-white/5"
+                          onClick={() => setSelectedRecord(record)}
+                        >
+                          <td className="px-4 py-4 font-mono text-sm">{record.bookingId}</td>
                           <td className="px-4 py-4">
                             <div className="font-medium">{formatBookingDate(record.date)}</div>
                             <div className="text-muted-foreground">{record.timeSlot}</div>
                           </td>
-                          <td className="px-4 py-4">
-                            <div className="font-medium">{record.name}</div>
-                            <div className="text-muted-foreground">{record.email}</div>
-                            {record.company && <div className="text-muted-foreground">{record.company}</div>}
-                          </td>
-                          <td className="px-4 py-4">
-                            <div>{formatBookingType(record.bookingType)}</div>
-                            {record.location && <div className="text-muted-foreground">{record.location}</div>}
-                          </td>
+                          <td className="px-4 py-4 font-medium">{record.name}</td>
+                          <td className="px-4 py-4">{formatBookingType(record.bookingType)}</td>
                           <td className="px-4 py-4">
                             <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
                               {formatStatus(record.status)}
                             </span>
-                          </td>
-                          <td className="px-4 py-4">
-                            <div className="space-y-1">
-                              <div className="line-clamp-3 text-muted-foreground">{record.agenda}</div>
-                              <div className="text-xs text-muted-foreground">作成: {formatDateTime(record.createdAt)}</div>
-                              <div className="text-xs text-muted-foreground">更新: {formatDateTime(record.updatedAt)}</div>
-                            </div>
                           </td>
                         </tr>
                       ))}
@@ -240,11 +269,16 @@ export default function AppointmentAdminPage() {
 
               <div className="space-y-4 md:hidden">
                 {filteredRecords.map((record) => (
-                  <article key={record.id} className="rounded-2xl border border-border bg-background/60 p-4">
+                  <button
+                    key={record.id}
+                    type="button"
+                    onClick={() => setSelectedRecord(record)}
+                    className="block w-full rounded-2xl border border-border bg-background/60 p-4 text-left"
+                  >
                     <div className="flex items-start justify-between gap-3">
                       <div>
-                        <h2 className="font-semibold">{record.name}</h2>
-                        <p className="text-sm text-muted-foreground">{record.email}</p>
+                        <p className="font-mono text-xs text-cyan-300">{record.bookingId}</p>
+                        <h2 className="mt-1 font-semibold">{record.name}</h2>
                       </div>
                       <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
                         {formatStatus(record.status)}
@@ -259,24 +293,8 @@ export default function AppointmentAdminPage() {
                         <dt className="text-muted-foreground">方式</dt>
                         <dd className="text-right">{formatBookingType(record.bookingType)}</dd>
                       </div>
-                      {record.location && (
-                        <div className="flex items-start justify-between gap-4">
-                          <dt className="text-muted-foreground">場所</dt>
-                          <dd className="text-right">{record.location}</dd>
-                        </div>
-                      )}
-                      {record.company && (
-                        <div className="flex items-start justify-between gap-4">
-                          <dt className="text-muted-foreground">会社名</dt>
-                          <dd className="text-right">{record.company}</dd>
-                        </div>
-                      )}
-                      <div>
-                        <dt className="text-muted-foreground">相談内容</dt>
-                        <dd className="mt-1 whitespace-pre-wrap text-sm">{record.agenda}</dd>
-                      </div>
                     </dl>
-                  </article>
+                  </button>
                 ))}
 
                 {!loading && filteredRecords.length === 0 && (
@@ -285,10 +303,164 @@ export default function AppointmentAdminPage() {
                   </div>
                 )}
               </div>
-            </div>
-          </div>
+            </TabsContent>
+
+            <TabsContent value="calendar" className="mt-4">
+              <div className="grid gap-4 lg:grid-cols-[420px_minmax(0,1fr)]">
+                <div className="rounded-2xl border border-border bg-background/60 p-3">
+                  <Calendar
+                    mode="single"
+                    locale={ja}
+                    selected={calendarDate}
+                    onSelect={setCalendarDate}
+                    modifiers={{
+                      booked: filteredRecords.map((record) => new Date(`${record.date}T00:00:00+09:00`)),
+                      selectedBooked: filteredRecords
+                        .filter((record) => sameDate(calendarDate, record.date))
+                        .map((record) => new Date(`${record.date}T00:00:00+09:00`)),
+                    }}
+                    modifiersClassNames={{
+                      booked: "bg-cyan-500/15 text-cyan-100 font-semibold",
+                      selectedBooked: "bg-cyan-500 text-black hover:bg-cyan-400",
+                    }}
+                    className="mx-auto"
+                  />
+                </div>
+
+                <div className="rounded-2xl border border-border bg-background/60 p-4">
+                  <div className="border-b border-border pb-4">
+                    <p className="text-sm text-muted-foreground">選択日</p>
+                    <h2 className="text-xl font-semibold">
+                      {selectedDateKey ? formatBookingDate(selectedDateKey) : "日付を選択してください"}
+                    </h2>
+                  </div>
+
+                  <div className="mt-4 space-y-3">
+                    {calendarRecords.map((record) => (
+                      <button
+                        key={record.id}
+                        type="button"
+                        onClick={() => setSelectedRecord(record)}
+                        className="block w-full rounded-2xl border border-border bg-card px-4 py-3 text-left transition-colors hover:bg-white/5"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="font-mono text-xs text-cyan-300">{record.bookingId}</p>
+                            <p className="mt-1 font-medium">{record.name}</p>
+                          </div>
+                          <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
+                            {formatStatus(record.status)}
+                          </span>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                          <span>{record.timeSlot}</span>
+                          <span>{formatBookingType(record.bookingType)}</span>
+                        </div>
+                      </button>
+                    ))}
+
+                    {!loading && calendarRecords.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+                        この日の予約はありません。
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
         </div>
       </section>
+
+      <Dialog open={Boolean(selectedRecord)} onOpenChange={(open) => !open && setSelectedRecord(null)}>
+        <DialogContent className="max-w-2xl">
+          {selectedRecord && (
+            <>
+              <DialogHeader>
+                <DialogTitle>予約詳細</DialogTitle>
+                <DialogDescription>
+                  予約番号 {selectedRecord.bookingId} / {selectedRecord.name}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">日時</p>
+                  <p className="mt-1 font-medium">{formatBookingDate(selectedRecord.date)} {selectedRecord.timeSlot}</p>
+                </div>
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">方式 / ステータス</p>
+                  <p className="mt-1 font-medium">
+                    {formatBookingType(selectedRecord.bookingType)} / {formatStatus(selectedRecord.status)}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">予約者</p>
+                  <p className="mt-1 font-medium">{selectedRecord.name}</p>
+                  {selectedRecord.company && <p className="text-sm text-muted-foreground">{selectedRecord.company}</p>}
+                </div>
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">メールアドレス</p>
+                  <p className="mt-1 break-all font-medium">{selectedRecord.email}</p>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <p className="text-xs text-muted-foreground">相談内容</p>
+                <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{selectedRecord.agenda}</p>
+              </div>
+
+              {selectedRecord.location && (
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">場所</p>
+                  <p className="mt-1 font-medium">{selectedRecord.location}</p>
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">作成日時</p>
+                  <p className="mt-1 text-sm">{formatDateTime(selectedRecord.createdAt)}</p>
+                </div>
+                <div className="rounded-xl border border-border bg-background/60 p-4">
+                  <p className="text-xs text-muted-foreground">更新日時</p>
+                  <p className="mt-1 text-sm">{formatDateTime(selectedRecord.updatedAt)}</p>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <p className="text-xs text-muted-foreground">関連リンク</p>
+                <div className="mt-2 space-y-2 text-sm">
+                  {selectedRecord.meetUrl && (
+                    <p>
+                      Meet:{" "}
+                      <a href={selectedRecord.meetUrl} target="_blank" rel="noreferrer" className="text-cyan-300 underline">
+                        {selectedRecord.meetUrl}
+                      </a>
+                    </p>
+                  )}
+                  {selectedRecord.calendarEventUrl && (
+                    <p>
+                      Google Calendar:{" "}
+                      <a
+                        href={selectedRecord.calendarEventUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-cyan-300 underline"
+                      >
+                        予定を開く
+                      </a>
+                    </p>
+                  )}
+                  {!selectedRecord.meetUrl && !selectedRecord.calendarEventUrl && (
+                    <p className="text-muted-foreground">関連リンクはありません。</p>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </main>
   )
 }

--- a/app/appointment/admin/page.tsx
+++ b/app/appointment/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { format } from "date-fns"
 import { ja } from "date-fns/locale"
 import { Button } from "@/components/ui/button"
@@ -57,8 +57,6 @@ function getStatusClassName(value: BookingStatus): string {
 }
 
 export default function AppointmentAdminPage() {
-  const [adminKey, setAdminKey] = useState("")
-  const [authenticated, setAuthenticated] = useState(false)
   const [records, setRecords] = useState<AdminBookingRecord[]>([])
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState("")
@@ -68,7 +66,7 @@ export default function AppointmentAdminPage() {
     query: "",
   })
 
-  const loadBookings = async (nextFilters = filters, key = adminKey) => {
+  const loadBookings = async (nextFilters = filters) => {
     setLoading(true)
     setMessage("")
     try {
@@ -76,20 +74,14 @@ export default function AppointmentAdminPage() {
       if (nextFilters.date) params.set("date", nextFilters.date)
       if (nextFilters.status !== "all") params.set("status", nextFilters.status)
 
-      const response = await fetch(`/api/bookings/admin?${params.toString()}`, {
-        headers: {
-          "x-booking-admin-key": key,
-        },
-      })
+      const response = await fetch(`/api/bookings/admin?${params.toString()}`)
       const json = await response.json()
       if (!response.ok || !json.ok) {
-        setAuthenticated(false)
         setRecords([])
         setMessage(json.message || "予約一覧を取得できませんでした。")
         return
       }
 
-      setAuthenticated(true)
       setRecords(Array.isArray(json.records) ? (json.records as AdminBookingRecord[]) : [])
     } catch {
       setMessage("通信エラーが発生しました。時間をおいて再度お試しください。")
@@ -108,6 +100,10 @@ export default function AppointmentAdminPage() {
         .includes(keyword)
     )
   }, [filters.query, records])
+
+  useEffect(() => {
+    void loadBookings()
+  }, [])
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -128,19 +124,7 @@ export default function AppointmentAdminPage() {
 
           <div className="mt-6 grid gap-4 lg:grid-cols-[280px_minmax(0,1fr)]">
             <aside className="rounded-2xl border border-border bg-background/60 p-4">
-              <div>
-                <Label htmlFor="adminKey">管理画面キー</Label>
-                <Input
-                  id="adminKey"
-                  type="password"
-                  value={adminKey}
-                  onChange={(event) => setAdminKey(event.target.value)}
-                  placeholder="BOOKING_ADMIN_KEY"
-                  className="mt-2"
-                />
-              </div>
-
-              <div className="mt-4 space-y-4">
+              <div className="space-y-4">
                 <div>
                   <Label htmlFor="filterDate">日付で絞り込み</Label>
                   <Input
@@ -180,8 +164,8 @@ export default function AppointmentAdminPage() {
               </div>
 
               <div className="mt-5 flex flex-col gap-2">
-                <Button onClick={() => void loadBookings()} disabled={loading || !adminKey}>
-                  {loading ? "読み込み中..." : authenticated ? "再読み込み" : "認証して一覧表示"}
+                <Button onClick={() => void loadBookings()} disabled={loading}>
+                  {loading ? "読み込み中..." : "再読み込み"}
                 </Button>
                 <Button
                   type="button"
@@ -189,9 +173,7 @@ export default function AppointmentAdminPage() {
                   onClick={() => {
                     const resetFilters = { date: "", status: "all", query: "" }
                     setFilters(resetFilters)
-                    if (authenticated) {
-                      void loadBookings(resetFilters)
-                    }
+                    void loadBookings(resetFilters)
                   }}
                 >
                   絞り込みをリセット

--- a/app/appointment/manage/[id]/page.tsx
+++ b/app/appointment/manage/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 
 interface ManageRecord {
   id: string
+  bookingId: string
   name: string
   email: string
   company?: string | null
@@ -222,6 +223,7 @@ export default function ManageBookingPage() {
           title: "予約変更完了",
           detail: `${date} ${timeSlot}`,
           infoLines: [
+            `予約番号: ${record?.bookingId || "-"}`,
             `日程: ${date}`,
             `時間: ${timeSlot}`,
             `形式: ${bookingType === "meet" ? "Google Meet" : "対面"}`,
@@ -255,6 +257,7 @@ export default function ManageBookingPage() {
           title: "予約キャンセル完了",
           detail: `${form.date} ${form.timeSlot}`,
           infoLines: [
+            `予約番号: ${record?.bookingId || "-"}`,
             `日程: ${form.date}`,
             `時間: ${form.timeSlot}`,
             `形式: ${bookingType === "meet" ? "Google Meet" : "対面"}`,
@@ -336,6 +339,7 @@ export default function ManageBookingPage() {
             <div className="space-y-4 rounded-xl border border-border bg-card p-6">
               <h2 className="text-xl font-semibold">現在の予約状況</h2>
               <p className="text-sm text-muted-foreground">対象: {record.name} / {record.email}</p>
+              <p className="text-sm text-cyan-300">予約番号: {record.bookingId}</p>
 
               <div className="grid gap-3 text-sm sm:grid-cols-2">
                 <div className="rounded-lg border border-border p-3">

--- a/lib/booking-portal.ts
+++ b/lib/booking-portal.ts
@@ -137,6 +137,33 @@ async function getPortalRecord(id: string): Promise<BookingPortalRecord | null> 
   return rows[0] || null
 }
 
+async function bookingIdExists(bookingId: string): Promise<boolean> {
+  const response = await supabaseFetch(
+    `booking_portal?booking_id=eq.${encodeURIComponent(bookingId)}&select=id&limit=1`
+  )
+  if (!response.ok) throw new Error(`Failed to check booking id: ${await response.text()}`)
+  const rows = (await response.json()) as Array<Pick<BookingPortalRecord, "id">>
+  return rows.length > 0
+}
+
+export async function generateBookingReference(): Promise<string> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const candidate = String(Math.floor(100000000 + Math.random() * 900000000))
+    try {
+      if (!(await bookingIdExists(candidate))) {
+        return candidate
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("Supabase env missing")) {
+        return candidate
+      }
+      throw error
+    }
+  }
+
+  throw new Error("Failed to generate a unique booking reference")
+}
+
 export async function listBookingPortals(filters: ListBookingPortalsFilters = {}): Promise<BookingPortalRecord[]> {
   const params = new URLSearchParams({
     select: "*",

--- a/lib/booking-portal.ts
+++ b/lib/booking-portal.ts
@@ -24,6 +24,11 @@ export interface BookingPortalRecord {
   updated_at: string
 }
 
+interface ListBookingPortalsFilters {
+  date?: string
+  status?: BookingPortalStatus | "all"
+}
+
 interface CreatePortalInput {
   bookingId: string
   name: string
@@ -130,6 +135,25 @@ async function getPortalRecord(id: string): Promise<BookingPortalRecord | null> 
   if (!response.ok) throw new Error(`Failed to fetch booking portal: ${await response.text()}`)
   const rows = (await response.json()) as BookingPortalRecord[]
   return rows[0] || null
+}
+
+export async function listBookingPortals(filters: ListBookingPortalsFilters = {}): Promise<BookingPortalRecord[]> {
+  const params = new URLSearchParams({
+    select: "*",
+    order: "date.desc,time_slot.desc,created_at.desc",
+  })
+
+  if (filters.date) {
+    params.set("date", `eq.${filters.date}`)
+  }
+
+  if (filters.status && filters.status !== "all") {
+    params.set("status", `eq.${filters.status}`)
+  }
+
+  const response = await supabaseFetch(`booking_portal?${params.toString()}`)
+  if (!response.ok) throw new Error(`Failed to list booking portals: ${await response.text()}`)
+  return (await response.json()) as BookingPortalRecord[]
 }
 
 export async function verifyPortalAccess(id: string, token: string, password?: string): Promise<PortalAccess> {

--- a/lib/discord-concierge.ts
+++ b/lib/discord-concierge.ts
@@ -1,0 +1,124 @@
+type ConciergeNotificationKind = "created" | "updated" | "canceled"
+
+interface ConciergeBookingPayload {
+  bookingId: string
+  name: string
+  email: string
+  company?: string | null
+  bookingType: "meet" | "対面"
+  date: string
+  timeSlot: string
+  agenda: string
+  location?: string | null
+  status: string
+  meetUrl?: string | null
+  calendarEventUrl?: string | null
+}
+
+function getWebhookUrl(): string | null {
+  return process.env.DISCORD_CONCIERGE_WEBHOOK_URL || null
+}
+
+function getAdminUrl(): string | null {
+  const base =
+    process.env.BOOKING_ADMIN_BASE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.BOOKING_PORTAL_BASE_URL
+  if (!base) return null
+  return `${base.replace(/\/$/, "")}/appointment/admin`
+}
+
+function truncate(value: string, max = 280): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
+function buildMessage(kind: ConciergeNotificationKind) {
+  if (kind === "created") {
+    return {
+      title: "新しいご予約を承りました",
+      description: "コンシェルジュよりご案内です。新しいお打ち合わせのご予約が入りました。ご都合のよいタイミングでご確認くださいませ。",
+      color: 0x7dd3fc,
+    }
+  }
+
+  if (kind === "updated") {
+    return {
+      title: "ご予約内容が更新されました",
+      description: "コンシェルジュよりご報告です。既存のご予約内容に変更がございました。最新情報をご確認くださいませ。",
+      color: 0xfbbf24,
+    }
+  }
+
+  return {
+    title: "ご予約がキャンセルされました",
+    description: "コンシェルジュよりご連絡です。ご予約のキャンセルを承りました。必要に応じてご確認くださいませ。",
+    color: 0xfb7185,
+  }
+}
+
+export async function sendDiscordConciergeNotification(
+  kind: ConciergeNotificationKind,
+  booking: ConciergeBookingPayload
+) {
+  const webhookUrl = getWebhookUrl()
+  if (!webhookUrl) {
+    return { sent: false, reason: "DISCORD_CONCIERGE_WEBHOOK_URL missing" }
+  }
+
+  const adminUrl = getAdminUrl()
+  const theme = buildMessage(kind)
+  const formatLine = booking.bookingType === "meet" ? "Google Meet" : `対面${booking.location ? ` / ${booking.location}` : ""}`
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      username: "コンシェルジュ",
+      content: "ご予約に関する最新のお知らせをお届けします。",
+      allowed_mentions: { parse: [] },
+      embeds: [
+        {
+          title: theme.title,
+          description: theme.description,
+          color: theme.color,
+          fields: [
+            { name: "予約番号", value: `\`${booking.bookingId}\``, inline: true },
+            { name: "ステータス", value: booking.status, inline: true },
+            { name: "方式", value: formatLine, inline: true },
+            { name: "予約者", value: booking.company ? `${booking.company} / ${booking.name}` : booking.name, inline: true },
+            { name: "メール", value: booking.email, inline: true },
+            { name: "日時", value: `${booking.date} ${booking.timeSlot}`, inline: true },
+            { name: "ご相談内容", value: truncate(booking.agenda) || "-", inline: false },
+            {
+              name: "管理画面",
+              value: adminUrl ? `[予約管理ページを開く](${adminUrl})` : "BOOKING_ADMIN_BASE_URL または NEXT_PUBLIC_SITE_URL を設定するとリンクを表示できます。",
+              inline: false,
+            },
+            {
+              name: "関連リンク",
+              value:
+                booking.meetUrl || booking.calendarEventUrl
+                  ? [booking.meetUrl ? `[Meet](${booking.meetUrl})` : null, booking.calendarEventUrl ? `[Calendar](${booking.calendarEventUrl})` : null]
+                      .filter(Boolean)
+                      .join(" / ")
+                  : "なし",
+              inline: false,
+            },
+          ],
+          footer: {
+            text: "DOKKIITECH Concierge",
+          },
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    }),
+  })
+
+  if (!response.ok) {
+    return { sent: false, reason: await response.text() }
+  }
+
+  return { sent: true }
+}

--- a/lib/discord-concierge.ts
+++ b/lib/discord-concierge.ts
@@ -68,6 +68,7 @@ export async function sendDiscordConciergeNotification(
   const adminUrl = getAdminUrl()
   const theme = buildMessage(kind)
   const formatLine = booking.bookingType === "meet" ? "Google Meet" : `対面${booking.location ? ` / ${booking.location}` : ""}`
+  const guestLabel = booking.company ? `${booking.company}\n${booking.name}` : booking.name
 
   const response = await fetch(webhookUrl, {
     method: "POST",
@@ -87,7 +88,7 @@ export async function sendDiscordConciergeNotification(
             { name: "予約番号", value: `\`${booking.bookingId}\``, inline: true },
             { name: "ステータス", value: booking.status, inline: true },
             { name: "方式", value: formatLine, inline: true },
-            { name: "予約者", value: booking.company ? `${booking.company} / ${booking.name}` : booking.name, inline: true },
+            { name: "予約者", value: guestLabel, inline: true },
             { name: "メール", value: booking.email, inline: true },
             { name: "日時", value: `${booking.date} ${booking.timeSlot}`, inline: true },
             { name: "ご相談内容", value: truncate(booking.agenda) || "-", inline: false },


### PR DESCRIPTION
## Summary
- add an admin bookings API protected by BOOKING_ADMIN_KEY
- add a responsive Japanese admin page to browse all bookings with date/status filters
- preserve the existing user booking and self-service management flows

## Verification
- npm run build
