### PR TITLE
Add booking ID copy buttons

### DIFF
--- a/app/appointment/admin/page.tsx
+++ b/app/appointment/admin/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { CopyBookingIdButton } from "@/components/copy-booking-id-button"
 
 type BookingStatus = "active" | "canceled" | "expired"
 
@@ -241,7 +242,12 @@ export default function AppointmentAdminPage() {
                           className="cursor-pointer transition-colors hover:bg-white/5"
                           onClick={() => setSelectedRecord(record)}
                         >
-                          <td className="px-4 py-4 font-mono text-sm">{record.bookingId}</td>
+                          <td className="px-4 py-4">
+                            <div className="flex items-center gap-2">
+                              <span className="font-mono text-sm">{record.bookingId}</span>
+                              <CopyBookingIdButton bookingId={record.bookingId} size="icon" className="h-8 w-8 shrink-0" />
+                            </div>
+                          </td>
                           <td className="px-4 py-4">
                             <div className="font-medium">{formatBookingDate(record.date)}</div>
                             <div className="text-muted-foreground">{record.timeSlot}</div>
@@ -269,15 +275,13 @@ export default function AppointmentAdminPage() {
 
               <div className="space-y-4 md:hidden">
                 {filteredRecords.map((record) => (
-                  <button
-                    key={record.id}
-                    type="button"
-                    onClick={() => setSelectedRecord(record)}
-                    className="block w-full rounded-2xl border border-border bg-background/60 p-4 text-left"
-                  >
+                  <div key={record.id} className="rounded-2xl border border-border bg-background/60 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
-                        <p className="font-mono text-xs text-cyan-300">{record.bookingId}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="font-mono text-xs text-cyan-300">{record.bookingId}</p>
+                          <CopyBookingIdButton bookingId={record.bookingId} size="icon" className="h-7 w-7 shrink-0" />
+                        </div>
                         <h2 className="mt-1 font-semibold">{record.name}</h2>
                       </div>
                       <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
@@ -294,7 +298,10 @@ export default function AppointmentAdminPage() {
                         <dd className="text-right">{formatBookingType(record.bookingType)}</dd>
                       </div>
                     </dl>
-                  </button>
+                    <Button type="button" variant="ghost" className="mt-4 w-full" onClick={() => setSelectedRecord(record)}>
+                      詳細を見る
+                    </Button>
+                  </div>
                 ))}
 
                 {!loading && filteredRecords.length === 0 && (
@@ -337,15 +344,13 @@ export default function AppointmentAdminPage() {
 
                   <div className="mt-4 space-y-3">
                     {calendarRecords.map((record) => (
-                      <button
-                        key={record.id}
-                        type="button"
-                        onClick={() => setSelectedRecord(record)}
-                        className="block w-full rounded-2xl border border-border bg-card px-4 py-3 text-left transition-colors hover:bg-white/5"
-                      >
+                      <div key={record.id} className="rounded-2xl border border-border bg-card px-4 py-3 transition-colors hover:bg-white/5">
                         <div className="flex items-start justify-between gap-3">
                           <div>
-                            <p className="font-mono text-xs text-cyan-300">{record.bookingId}</p>
+                            <div className="flex items-center gap-2">
+                              <p className="font-mono text-xs text-cyan-300">{record.bookingId}</p>
+                              <CopyBookingIdButton bookingId={record.bookingId} size="icon" className="h-7 w-7 shrink-0" />
+                            </div>
                             <p className="mt-1 font-medium">{record.name}</p>
                           </div>
                           <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-medium ${getStatusClassName(record.status)}`}>
@@ -356,7 +361,10 @@ export default function AppointmentAdminPage() {
                           <span>{record.timeSlot}</span>
                           <span>{formatBookingType(record.bookingType)}</span>
                         </div>
-                      </button>
+                        <Button type="button" variant="ghost" className="mt-4 w-full" onClick={() => setSelectedRecord(record)}>
+                          詳細を見る
+                        </Button>
+                      </div>
                     ))}
 
                     {!loading && calendarRecords.length === 0 && (
@@ -382,6 +390,10 @@ export default function AppointmentAdminPage() {
                   予約番号 {selectedRecord.bookingId} / {selectedRecord.name}
                 </DialogDescription>
               </DialogHeader>
+
+              <div className="flex justify-start">
+                <CopyBookingIdButton bookingId={selectedRecord.bookingId} className="w-full sm:w-auto" />
+              </div>
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="rounded-xl border border-border bg-background/60 p-4">

--- a/app/appointment/manage/[id]/page.tsx
+++ b/app/appointment/manage/[id]/page.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Calendar } from "@/components/ui/calendar"
 import { BookingCompletionScreen } from "@/components/booking-completion-screen"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+import { CopyBookingIdButton } from "@/components/copy-booking-id-button"
 
 interface ManageRecord {
   id: string
@@ -337,9 +338,14 @@ export default function ManageBookingPage() {
         {step === "manage" && record && (
           <div className="mt-8 space-y-6">
             <div className="space-y-4 rounded-xl border border-border bg-card p-6">
-              <h2 className="text-xl font-semibold">現在の予約状況</h2>
-              <p className="text-sm text-muted-foreground">対象: {record.name} / {record.email}</p>
-              <p className="text-sm text-cyan-300">予約番号: {record.bookingId}</p>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold">現在の予約状況</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">対象: {record.name} / {record.email}</p>
+                  <p className="mt-1 text-sm text-cyan-300">予約番号: {record.bookingId}</p>
+                </div>
+                <CopyBookingIdButton bookingId={record.bookingId} className="w-full sm:w-auto" />
+              </div>
 
               <div className="grid gap-3 text-sm sm:grid-cols-2">
                 <div className="rounded-lg border border-border p-3">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { Navigation } from "@/components/navigation"
 import { FirstVisitLoader } from "@/components/first-visit-loader"
 import { CtrlCTerminalShortcut } from "@/components/ctrl-c-terminal-shortcut"
+import { Toaster } from "@/components/ui/toaster"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -73,6 +74,7 @@ export default function RootLayout({
           <CtrlCTerminalShortcut />
           <Navigation />
           <div className="pt-16">{children}</div>
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/components/copy-booking-id-button.tsx
+++ b/components/copy-booking-id-button.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import type { MouseEvent } from "react"
+import { Copy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { toast } from "@/hooks/use-toast"
+
+interface CopyBookingIdButtonProps {
+  bookingId: string
+  className?: string
+  variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link"
+  size?: "default" | "sm" | "lg" | "icon"
+}
+
+export function CopyBookingIdButton({
+  bookingId,
+  className,
+  variant = "outline",
+  size = "sm",
+}: CopyBookingIdButtonProps) {
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    try {
+      if (!navigator?.clipboard) {
+        throw new Error("Clipboard API unavailable")
+      }
+
+      await navigator.clipboard.writeText(bookingId)
+      toast({
+        title: "予約番号をコピーしました",
+        description: `予約番号 ${bookingId} をクリップボードにコピーしました。`,
+      })
+    } catch {
+      toast({
+        title: "コピーに失敗しました",
+        description: "お手数ですが、予約番号を手動でコピーしてください。",
+        variant: "destructive",
+      })
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={handleCopy}
+      aria-label={`予約番号 ${bookingId} をコピー`}
+      title="予約番号をコピー"
+    >
+      <Copy />
+      {size === "icon" ? <span className="sr-only">コピー</span> : "コピー"}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable booking ID copy button component with Japanese success/error feedback
- add copy actions to the self-service booking page and admin booking views
- include the shared toaster in the app layout so copy feedback is visible

## Verification
- npm run build
- npm run lint (fails because eslint is not installed in this repo)